### PR TITLE
Add exit item when the menu has no items

### DIFF
--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -129,10 +129,9 @@ class ConsoleMenu(object):
         :return: True if item needed to be added, False otherwise
         :rtype: bool
         """
-        if self.items:
-            if self.items[-1] is not self.exit_item:
-                self.items.append(self.exit_item)
-                return True
+        if not self.items or self.items[-1] is not self.exit_item:
+            self.items.append(self.exit_item)
+            return True
         return False
 
     def remove_exit(self):


### PR DESCRIPTION
When you create a ConsoleMenu with no items (for instance when you are testing, or you just want to show some info), the `show_exit_option` option has no effect.
This small change adds the entry even when the has no Items.

I did some manual testing and ran the unittest. It seems to be working properly.

Let me know what you think, please.