### PR TITLE
Fix failure to clear screen under Windows 10 ssh

### DIFF
--- a/consolemenu/screen.py
+++ b/consolemenu/screen.py
@@ -1,11 +1,10 @@
 from __future__ import print_function
 
 import platform
+import subprocess
 import sys
 import textwrap
 from collections import namedtuple
-
-import os
 
 from consolemenu.validators.base import BaseValidator, InvalidValidator
 
@@ -38,9 +37,9 @@ class Screen(object):
     @staticmethod
     def clear():
         if platform.system() == 'Windows':
-            os.system('cls')
+            subprocess.check_call('cls', shell=True)
         else:
-            os.system('clear')
+            print(subprocess.check_output('clear').decode())
 
     def input(self, prompt='', validators=None, default=None, enable_quit=False, quit_string='q',
               quit_message='(enter q to Quit)'):


### PR DESCRIPTION
Occasionally when connected to a Linux machine using Windows 10's native
ssh client, the screen doesn't get cleared between two attempts to draw
the screen. This seems to be due to the `clear` process writing the
control codes to its own copy of standard out, which isn't doesn't seem
to flushed to the screen at the same time as Python writes out the menu.

This patch causes Python to capture the control codes used by `clear`,
and writes them to the script's own standard output.

On Windows, the same trick doesn't work (Python writes '\f'/'\x0c',
which displays as ♀/'\u2640', see en.wikipedia.org/wiki/Code_page_437).
Instead, this patch continues to just call `cls`, but uses 'subprocess'
for consistency.