### PR TITLE
Handle colours in menu item names

### DIFF
--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -303,7 +303,12 @@ class ConsoleMenu(object):
         """
         Gets the next single character and decides what to do with it
         """
-        user_input = self.get_input()
+
+        try:
+            user_input = self.get_input()
+        except EOFError:
+            self.should_exit = True
+            return
 
         try:
             num = int(user_input)

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -1,4 +1,4 @@
-import textwrap
+import ansiwrap
 
 from consolemenu.format import MenuStyle
 
@@ -187,11 +187,12 @@ class MenuComponent(object):
             return '<'
 
     def _format_content(self, content='', align='left'):
+        invisible_chars = len(content) - ansiwrap.ansilen(content)
         return '{lp}{text:{al}{width}}{rp}'.format(lp=' ' * self.padding.left,
                                                    rp=' ' * self.padding.right,
                                                    text=content, al=self._alignment_char(align),
                                                    width=(self.calculate_border_width() - self.padding.left -
-                                                          self.padding.right - 2))
+                                                          self.padding.right - 2 + invisible_chars))
 
 
 class MenuHeader(MenuComponent):
@@ -247,7 +248,7 @@ class MenuTextSection(MenuComponent):
         for x in range(0, self.padding.top):
             yield self.row()
         if self.text is not None and self.text != '':
-            for line in textwrap.wrap(self.text, width=self.calculate_content_width()):
+            for line in ansiwrap.wrap(self.text, width=self.calculate_content_width()):
                 yield self.row(content=line, align=self.text_align)
         for x in range(0, self.padding.bottom):
             yield self.row()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pycodestyle>=2.3.1
 pytest>=2.8.7
 six
 mock
+ansiwrap

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     description='A simple console menu system',
     long_description=read("README.rst", "CHANGELOG.rst"),
     packages=find_packages(),
-    install_requires=['six'],
+    install_requires=['six', 'ansiwrap'],
     # setup_requires=['pytest-runner'],
     # tests_require=['tox'],
     # cmdclass={'test': Tox},


### PR DESCRIPTION
By utilising the lovely `ansiwrap` library to add extra "invisible" padding, colours in item names no longer mess up the vertical alignment of the borders.
Before:
![image](https://user-images.githubusercontent.com/3398021/87507142-32f9d900-c6b0-11ea-872e-12c4640f2fdf.png)
After:
![image](https://user-images.githubusercontent.com/3398021/87506524-dea22980-c6ae-11ea-95c5-5d82dd69477a.png)
