### PR TITLE
handle text wrapping within all sections of the menu

### DIFF
--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -431,7 +431,6 @@ class MenuItem(object):
         :return: The representation of the item to be shown in a menu
         :rtype: str
         """
-        print(available_width)
         content = "%2d - %s" % (index + 1, self.get_text())
         if available_width is None:
             return content

--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -432,10 +432,11 @@ class MenuItem(object):
         :rtype: str
         """
         content = "%2d - %s" % (index + 1, self.get_text())
-        return self._intelligent_split(content, max_width=available_width)
+        indent = 4 #1 for single digit number (more digits extend left), 3 for " - " separator 
+        return self._intelligent_split(content, max_width=available_width, item_indent=indent)
 
     @staticmethod
-    def _intelligent_split(string, max_width=None):
+    def _intelligent_split(string, max_width=None, item_indent=0):
         lines = []
         if max_width is None:
             return string
@@ -444,8 +445,10 @@ class MenuItem(object):
             for line in split:
                 # add spaces after newlines if they werent already added by the user.
                 # this preserves alignment with the numbered menu options
-                if line != split[0] and not line.startswith(" "):
-                    line = " " + line
+                if line != split[0]:
+                    if not line.startswith(" "):
+                        line = " " + line
+                    line = ' ' * item_indent + line
 
                 if len(line) < max_width:
                     lines.append(line)
@@ -457,7 +460,7 @@ class MenuItem(object):
                         word_split_index = remaining.rfind(" ", 0, max_width)
                         lines.append(remaining[:word_split_index])
                         # shorten remaining so the loop ends
-                        remaining = remaining[word_split_index:]
+                        remaining = ' ' * item_indent + remaining[word_split_index:]
                     lines.append(remaining)
 
         return lines

--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -414,6 +414,7 @@ class MenuItem(object):
         self.text = text
         self.menu = menu
         self.should_exit = should_exit
+        self.index_item_separator = " - "
 
     def __str__(self):
         return "%s %s" % (self.menu.get_title(), self.get_text())
@@ -432,7 +433,7 @@ class MenuItem(object):
         :return: The representation of the item to be shown in a menu
         :rtype: str
         """
-        return "%2d - %s" % (index + 1, self.get_text())
+        return "%2d%s%s" % (index + 1, self.index_item_separator, self.get_text())
 
     def set_up(self):
         """

--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -417,7 +417,7 @@ class MenuItem(object):
     def __str__(self):
         return "%s %s" % (self.menu.get_title(), self.get_text())
 
-    def show(self, index):
+    def show(self, index, available_width=None):
         """
         How this item should be displayed in the menu. Can be overridden, but should keep the same signature.
 
@@ -431,7 +431,12 @@ class MenuItem(object):
         :return: The representation of the item to be shown in a menu
         :rtype: str
         """
-        return "%2d - %s" % (index + 1, self.get_text())
+        print(available_width)
+        content = "%2d - %s" % (index + 1, self.get_text())
+        if available_width is None:
+            return content
+        else:
+            return [ content[start:start+available_width] for start in range(0, len(content), available_width) ]
 
     def set_up(self):
         """
@@ -474,7 +479,7 @@ class ExitItem(MenuItem):
     def __init__(self, text="Exit", menu=None):
         super(ExitItem, self).__init__(text=text, menu=menu, should_exit=True)
 
-    def show(self, index):
+    def show(self, index, available_width=None):
         """
         ExitItem overrides this method to display appropriate Exit or Return text.
         """

--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -432,10 +432,31 @@ class MenuItem(object):
         :rtype: str
         """
         content = "%2d - %s" % (index + 1, self.get_text())
-        if available_width is None:
-            return content
+        return self._intelligent_split(content, max_width=available_width)
+
+    @staticmethod
+    def _intelligent_split(string, max_width=None):
+        lines = []
+        if max_width is None:
+            return string
         else:
-            return [ content[start:start+available_width] for start in range(0, len(content), available_width) ]
+            split = string.split("\n")
+            for line in split:
+
+                if len(line) < max_width:
+                    lines.append(line)
+                else:
+                    # no newlines present and line is still too long
+                    remaining = line
+                    while len(remaining) > max_width:
+                        # find last space before width boundary and split on that
+                        word_split_index = remaining.rfind(" ", 0, max_width)
+                        lines.append(remaining[:word_split_index])
+                        # shorten remaining so the loop ends
+                        remaining = remaining[word_split_index:]
+                    lines.append(remaining)
+
+        return lines
 
     def set_up(self):
         """

--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import platform
 import threading
+import textwrap
 
 import os
 
@@ -417,7 +418,7 @@ class MenuItem(object):
     def __str__(self):
         return "%s %s" % (self.menu.get_title(), self.get_text())
 
-    def show(self, index, available_width=None):
+    def show(self, index):
         """
         How this item should be displayed in the menu. Can be overridden, but should keep the same signature.
 
@@ -431,39 +432,7 @@ class MenuItem(object):
         :return: The representation of the item to be shown in a menu
         :rtype: str
         """
-        content = "%2d - %s" % (index + 1, self.get_text())
-        indent = 4 #1 for single digit number (more digits extend left), 3 for " - " separator 
-        return self._intelligent_split(content, max_width=available_width, item_indent=indent)
-
-    @staticmethod
-    def _intelligent_split(string, max_width=None, item_indent=0):
-        lines = []
-        if max_width is None:
-            return string
-        else:
-            split = string.split("\n")
-            for line in split:
-                # add spaces after newlines if they werent already added by the user.
-                # this preserves alignment with the numbered menu options
-                if line != split[0]:
-                    if not line.startswith(" "):
-                        line = " " + line
-                    line = ' ' * item_indent + line
-
-                if len(line) < max_width:
-                    lines.append(line)
-                else:
-                    # no newlines present and line is still too long
-                    remaining = line
-                    while len(remaining) > max_width:
-                        # find last space before width boundary and split on that
-                        word_split_index = remaining.rfind(" ", 0, max_width)
-                        lines.append(remaining[:word_split_index])
-                        # shorten remaining so the loop ends
-                        remaining = ' ' * item_indent + remaining[word_split_index:]
-                    lines.append(remaining)
-
-        return lines
+        return "%2d - %s" % (index + 1, self.get_text())
 
     def set_up(self):
         """

--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -442,6 +442,10 @@ class MenuItem(object):
         else:
             split = string.split("\n")
             for line in split:
+                # add spaces after newlines if they werent already added by the user.
+                # this preserves alignment with the numbered menu options
+                if not line.startswith(" "):
+                    line = " " + line
 
                 if len(line) < max_width:
                     lines.append(line)

--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -444,7 +444,7 @@ class MenuItem(object):
             for line in split:
                 # add spaces after newlines if they werent already added by the user.
                 # this preserves alignment with the numbered menu options
-                if not line.startswith(" "):
+                if line != split[0] and not line.startswith(" "):
                     line = " " + line
 
                 if len(line) < max_width:

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -192,7 +192,7 @@ class MenuComponent(object):
                 # apply indentation to any lines after the first that were split by a users newline
                 line = indent + line
             # apply any wrapping and indentation if the line is still too long
-            wrapped = textwrap.wrap(line, width=self.calculate_content_width(), subsequent_indent=indent)
+            wrapped = ansiwrap.wrap(line, width=self.calculate_content_width(), subsequent_indent=indent)
             for wrapline in wrapped:
                 # Finally, this adds the borders and things to the string
                 # TODO: check compatability on super() calls
@@ -270,8 +270,7 @@ class MenuTextSection(MenuComponent):
         for x in range(0, self.padding.top):
             yield self.row()
         if self.text is not None and self.text != '':
-            for line in ansiwrap.wrap(self.text, width=self.calculate_content_width()):
-                yield self.row(content=line, align=self.text_align)
+            yield self.row(content=self.text, align=self.text_align)
         for x in range(0, self.padding.bottom):
             yield self.row()
         if self.show_bottom_border:

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -323,7 +323,9 @@ class MenuItemsSection(MenuComponent):
         for index, item in enumerate(self.items):
             if item.text in self.items_with_top_border:
                 yield self.inner_horizontal_border()
-            yield self.row(content=item.show(index), align=self.items_align, indent_len=self.padding.left)
+            # the length of the separator plus the length of the longest index number
+            indent_size = len(item.index_item_separator) + len(str(len(self.items)))
+            yield self.row(content=item.show(index), align=self.items_align, indent_len=indent_size)
             if item.text in self.items_with_bottom_border:
                 yield self.inner_horizontal_border()
         for x in range(0, self.padding.bottom):

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -323,7 +323,7 @@ class MenuItemsSection(MenuComponent):
         for index, item in enumerate(self.items):
             if item.text in self.items_with_top_border:
                 yield self.inner_horizontal_border()
-            yield self.row(content=item.show(index), align=self.items_align)
+            yield self.row(content=item.show(index, available_width=self.calculate_content_width()), align=self.items_align)
             if item.text in self.items_with_bottom_border:
                 yield self.inner_horizontal_border()
         for x in range(0, self.padding.bottom):

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -328,6 +328,18 @@ class MenuItemsSection(MenuComponent):
                 yield self.inner_horizontal_border()
         for x in range(0, self.padding.bottom):
             yield self.row()
+    
+    def row(self, content='', align='left'):
+        """wrapper script around row that handles multiple-line menu items and returns a single string
+        """
+        if isinstance(content, list):
+            lines = []
+            for line in content:
+                lines.append(super().row(line, align))
+            return '\n'.join(lines)
+        else:
+            return super().row(content, align)
+
 
 
 class MenuFooter(MenuComponent):

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -334,6 +334,8 @@ class MenuItemsSection(MenuComponent):
     def row(self, content='', align='left', indent_len=0):
         """wrapper script around row that handles breaking up arbitraty length content into wrapped lines while respecting user-included newline characters. returns a single string correctly formatted for the menu
         """
+        if len(content) == 0:
+            return super().row()
         # split on user newlines
         content = content.split("\n")
         lines = []

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -166,7 +166,7 @@ class MenuComponent(object):
                                           rv=self.border_style.top_right_corner,
                                           hz=self.outer_horizontals())
 
-    def row(self, content='', align='left'):
+    def _generate_single_row(self, content='', align='left'):
         """
         A row of the menu, which comprises the left and right verticals plus the given content.
 
@@ -176,6 +176,28 @@ class MenuComponent(object):
         return u"{lm}{vert}{cont}{vert}".format(lm=' ' * self.margins.left,
                                                 vert=self.border_style.outer_vertical,
                                                 cont=self._format_content(content, align))
+
+    def row(self, content='', align='left', indent_len=0):
+        """wrapper script around row that handles breaking up arbitraty length content into wrapped lines while respecting user-included newline characters. returns a single string correctly formatted for the menu
+        """
+        if len(content) == 0:
+            return self._generate_single_row()
+        # split on user newlines
+        content = content.splitlines()
+        lines = []
+        indent = ' '*indent_len
+
+        for line in content:
+            if line != content[0]:
+                # apply indentation to any lines after the first that were split by a users newline
+                line = indent + line
+            # apply any wrapping and indentation if the line is still too long
+            wrapped = textwrap.wrap(line, width=self.calculate_content_width(), subsequent_indent=indent)
+            for wrapline in wrapped:
+                # Finally, this adds the borders and things to the string
+                # TODO: check compatability on super() calls
+                lines.append(self._generate_single_row(wrapline, align))
+        return '\n'.join(lines)
 
     @staticmethod
     def _alignment_char(align):
@@ -331,27 +353,7 @@ class MenuItemsSection(MenuComponent):
         for x in range(0, self.padding.bottom):
             yield self.row()
     
-    def row(self, content='', align='left', indent_len=0):
-        """wrapper script around row that handles breaking up arbitraty length content into wrapped lines while respecting user-included newline characters. returns a single string correctly formatted for the menu
-        """
-        if len(content) == 0:
-            return super().row()
-        # split on user newlines
-        content = content.splitlines()
-        lines = []
-        indent = ' '*indent_len
-
-        for line in content:
-            if line != content[0]:
-                # apply indentation to any lines after the first that were split by a users newline
-                line = indent + line
-            # apply any wrapping and indentation if the line is still too long
-            wrapped = textwrap.wrap(line, width=self.calculate_content_width(), subsequent_indent=indent)
-            for wrapline in wrapped:
-                # Finally, this adds the borders and things to the string
-                # TODO: check compatability on super() calls
-                lines.append(super().row(wrapline, align))
-        return '\n'.join(lines)
+    
 
 
 

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -323,24 +323,31 @@ class MenuItemsSection(MenuComponent):
         for index, item in enumerate(self.items):
             if item.text in self.items_with_top_border:
                 yield self.inner_horizontal_border()
-            yield self.row(content=item.show(index, available_width=self.calculate_content_width()), align=self.items_align)
+            yield self.row(content=item.show(index), align=self.items_align, indent_len=self.padding.left)
             if item.text in self.items_with_bottom_border:
                 yield self.inner_horizontal_border()
         for x in range(0, self.padding.bottom):
             yield self.row()
     
-    def row(self, content='', align='left'):
-        """wrapper script around row that handles multiple-line menu items and returns a single string
+    def row(self, content='', align='left', indent_len=0):
+        """wrapper script around row that handles breaking up arbitraty length content into wrapped lines while respecting user-included newline characters. returns a single string correctly formatted for the menu
         """
-        if isinstance(content, list):
-            lines = []
-            for line in content:
+        # split on user newlines
+        content = content.split("\n")
+        lines = []
+        indent = ' '*indent_len
+
+        for line in content:
+            if line != content[0]:
+                # apply indentation to any lines after the first that were split by a users newline
+                line = indent + line
+            # apply any wrapping and indentation if the line is still too long
+            wrapped = textwrap.wrap(line, width=self.calculate_content_width(), subsequent_indent=indent)
+            for wrapline in wrapped:
+                # Finally, this adds the borders and things to the string
                 # TODO: check compatability on super() calls
-                lines.append(super().row(line, align))
-            return '\n'.join(lines)
-        else:
-            # TODO: check compatability on super() calls
-            return super().row(content, align)
+                lines.append(super().row(wrapline, align))
+        return '\n'.join(lines)
 
 
 

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -337,7 +337,7 @@ class MenuItemsSection(MenuComponent):
         if len(content) == 0:
             return super().row()
         # split on user newlines
-        content = content.split("\n")
+        content = content.splitlines()
         lines = []
         indent = ' '*indent_len
 

--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -335,9 +335,11 @@ class MenuItemsSection(MenuComponent):
         if isinstance(content, list):
             lines = []
             for line in content:
+                # TODO: check compatability on super() calls
                 lines.append(super().row(line, align))
             return '\n'.join(lines)
         else:
+            # TODO: check compatability on super() calls
             return super().row(content, align)
 
 


### PR DESCRIPTION


![Screenshot_20211106_215409](https://user-images.githubusercontent.com/17362949/140629402-ce545de2-e269-4336-9e28-7dc5ce9381a2.png)



fixes #29 

see the linked issue for some of the discussion on how this is accomplished. TL;DR if a list is returned by `MenuItem.show()`, it will be handles by an override of `row` in `MenuItemsSection` to generate one line of output for each item in the list.