### PR TITLE
Enable menu_char to take strings instead of just chars

### DIFF
--- a/consolemenu/console_menu.py
+++ b/consolemenu/console_menu.py
@@ -446,7 +446,7 @@ class MenuItem(object):
         if self.menu_char is None:
             ret = "%2d%s%s" % (index + 1, self.index_item_separator, self.get_text())
         else:
-            ret = " %c%s%s" % (self.menu_char, self.index_item_separator, self.get_text())
+            ret = " %s%s%s" % (self.menu_char, self.index_item_separator, self.get_text())
         return ret
 
     def set_up(self):


### PR DESCRIPTION
Changing %c from %s to enable the menu character to take strings instead of just chars.

I made this change so that I could use stuff like
```py
menu_char=color(item.index(), fg="red")
```
