### PR TITLE
Add ZeroBorder ( Borderless Menu )

### DIFF
--- a/consolemenu/format/__init__.py
+++ b/consolemenu/format/__init__.py
@@ -4,6 +4,7 @@ from .menu_borders import DoubleLineOuterLightInnerBorderStyle
 from .menu_borders import HeavyBorderStyle
 from .menu_borders import HeavyOuterLightInnerBorderStyle
 from .menu_borders import LightBorderStyle
+from .menu_borders import ZeroBorderStyle
 from .menu_borders import MenuBorderStyle
 from .menu_borders import MenuBorderStyleFactory
 from .menu_borders import MenuBorderStyleType
@@ -13,4 +14,4 @@ from .menu_style import MenuStyle
 
 __all__ = ['MenuBorderStyle', 'MenuBorderStyleType', 'MenuBorderStyleFactory', 'MenuMargins', 'MenuPadding',
            'MenuStyle', 'AsciiBorderStyle', 'LightBorderStyle', 'HeavyBorderStyle', 'DoubleLineBorderStyle',
-           'DoubleLineOuterLightInnerBorderStyle', 'HeavyOuterLightInnerBorderStyle']
+           'DoubleLineOuterLightInnerBorderStyle', 'HeavyOuterLightInnerBorderStyle', 'ZeroBorderStyle']

--- a/consolemenu/format/menu_borders.py
+++ b/consolemenu/format/menu_borders.py
@@ -1,5 +1,3 @@
-"""MODIFIED VERSION OF CONSOLEMENU"""
-
 import logging
 import sys
 

--- a/consolemenu/format/menu_borders.py
+++ b/consolemenu/format/menu_borders.py
@@ -1,3 +1,5 @@
+"""MODIFIED VERSION OF CONSOLEMENU"""
+
 import logging
 import sys
 
@@ -309,6 +311,51 @@ class DoubleLineOuterLightInnerBorderStyle(DoubleLineBorderStyle):
     def outer_vertical_inner_right(self): return u'\u255F'
 
 
+
+class ZeroBorderStyle(MenuBorderStyle):
+    """
+    A borderless border. This fills the border with blank characters
+    """
+
+    @property
+    def bottom_left_corner(self): return ''
+
+    @property
+    def bottom_right_corner(self): return ''
+
+    @property
+    def inner_horizontal(self): return ''
+
+    @property
+    def inner_vertical(self): return ''
+
+    @property
+    def intersection(self): return ''
+
+    @property
+    def outer_horizontal(self): return ''
+
+    @property
+    def outer_horizontal_inner_down(self): return ''
+
+    @property
+    def outer_horizontal_inner_up(self): return ''
+
+    @property
+    def outer_vertical(self): return ''
+
+    @property
+    def outer_vertical_inner_left(self): return ''
+
+    @property
+    def outer_vertical_inner_right(self): return ''
+
+    @property
+    def top_left_corner(self): return ''
+
+    @property
+    def top_right_corner(self): return ''
+
 class MenuBorderStyleType(object):
     """
     Defines the various menu border styles, as expected by the border factory.
@@ -339,6 +386,11 @@ class MenuBorderStyleType(object):
     DOUBLE_LINE_OUTER_LIGHT_INNER_BORDER = 5
     """ int: Menu Border using the "double-line" box drawing characters for the outer border elements, and "light"
         box-drawing characters for the inner border elements."""
+    
+    ZERO_BORDER = 6
+    """
+    int: Menu border that is borderless. This uses blank characters instead of borders.
+    """
 
 
 class MenuBorderStyleFactory(object):
@@ -372,6 +424,8 @@ class MenuBorderStyleFactory(object):
             return self.create_heavy_outer_light_inner_border()
         elif border_style_type == MenuBorderStyleType.DOUBLE_LINE_OUTER_LIGHT_INNER_BORDER:
             return self.create_doubleline_outer_light_inner_border()
+        elif border_style_type == MenuBorderStyleType.ZERO_BORDER:
+            return self.create_zero_border()
         else:
             # Use ASCII if we don't recognize the type
             self.logger.info('Unrecognized border style type: {}. Defaulting to ASCII.'.format(border_style_type))
@@ -449,6 +503,15 @@ class MenuBorderStyleFactory(object):
             :obj:`DoubleLineOuterLightInnerBorderStyle`: a new instance of DoubleLineOuterLightInnerBorderStyle
         """
         return DoubleLineOuterLightInnerBorderStyle()
+    
+    def create_zero_border(self):
+        """
+        Creates a zero border with blank characters.
+
+        Returns:
+            :obj:`ZeroBorder`: a new instance of ZeroBorderStyle
+        """
+        return ZeroBorderStyle()
 
     @staticmethod
     def is_win_python35_or_earlier():

--- a/consolemenu/format/menu_borders.py
+++ b/consolemenu/format/menu_borders.py
@@ -312,7 +312,7 @@ class DoubleLineOuterLightInnerBorderStyle(DoubleLineBorderStyle):
 
 class ZeroBorderStyle(MenuBorderStyle):
     """
-    A borderless border. This fills the border with blank characters
+    A borderless border. This fills the border with empty strings
     """
 
     @property
@@ -387,7 +387,7 @@ class MenuBorderStyleType(object):
     
     ZERO_BORDER = 6
     """
-    int: Menu border that is borderless. This uses blank characters instead of borders.
+    int: Menu border that is borderless. This uses empty strings instead of borders with characters.
     """
 
 
@@ -504,7 +504,7 @@ class MenuBorderStyleFactory(object):
     
     def create_zero_border(self):
         """
-        Creates a zero border with blank characters.
+        Creates a zero border with empty strings.
 
         Returns:
             :obj:`ZeroBorder`: a new instance of ZeroBorderStyle


### PR DESCRIPTION
Adds a ZeroBorder. This border has blank characters instead of an actual border. Here's what it looks like:


![image](https://github.com/aegirhall/console-menu/assets/70258998/848cd205-b283-4b23-bb08-818a817ebf11)

I made this change because pyinstaller broke my borders. This was a nice workaround to a problem I didn't want to debug plus it looked nicer.