### PR TITLE
Fix signed width value _format_content bug

### DIFF
--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -236,8 +236,8 @@ class MenuComponent(object):
         return '{lp}{text:{al}{width}}{rp}'.format(lp=' ' * self.padding.left,
                                                    rp=' ' * self.padding.right,
                                                    text=content, al=self._alignment_char(align),
-                                                   width=(self.calculate_border_width() - self.padding.left -
-                                                          self.padding.right - 2 + invisible_chars))
+                                                   width=max(self.calculate_border_width() - self.padding.left -
+                                                          self.padding.right - 2 + invisible_chars, 0))
 
 
 class MenuHeader(MenuComponent):


### PR DESCRIPTION
There is the possibility that the width value evaluates to a negative value which will throw a ValueError: Sign not allowed in string format specifier. Adding a minimum 0 value ensures that only positive values are used during string formatting.