### PR TITLE
Fix width out-of-bounds issues

### DIFF
--- a/consolemenu/menu_component.py
+++ b/consolemenu/menu_component.py
@@ -116,7 +116,7 @@ class MenuComponent(object):
         Returns:
             int: the inner content width in columns.
         """
-        return self.calculate_border_width() - self.padding.left - self.padding.right - 2
+        return max(self.calculate_border_width() - self.padding.left - self.padding.right - 2, 1)
 
     def generate(self):
         """
@@ -236,8 +236,8 @@ class MenuComponent(object):
         return '{lp}{text:{al}{width}}{rp}'.format(lp=' ' * self.padding.left,
                                                    rp=' ' * self.padding.right,
                                                    text=content, al=self._alignment_char(align),
-                                                   width=(self.calculate_border_width() - self.padding.left -
-                                                          self.padding.right - 2 + invisible_chars))
+                                                   width=max(self.calculate_border_width() - self.padding.left -
+                                                          self.padding.right - 2 + invisible_chars, 0))
 
 
 class MenuHeader(MenuComponent):


### PR DESCRIPTION
In _format_content there is the possibility that the width value evaluates to a negative value which will throw a ValueError: Sign not allowed in string format specifier. Adding a minimum 0 value ensures that only positive values are used during string formatting.

In calculate_content_width  the returned value can result in a value less than 1 which causes issues. Ensuring a value of 1 or greater solves this.